### PR TITLE
Add feature to call assert(...).(not)equal with sequences.

### DIFF
--- a/Sources/RxAssertion.swift
+++ b/Sources/RxAssertion.swift
@@ -146,6 +146,32 @@ extension RxAssertion {
     }
     return true
   }
+  
+  func eventEquals<E: Sequence>(_ lhs: Recorded<Event<E>>, _ rhs: Recorded<Event<E>>) -> Bool where E.Iterator.Element: Equatable {
+
+    let equals: Bool
+    switch(lhs.value.element, rhs.value.element) {
+    case (let left?, let right?):
+      equals = left.elementsEqual(right)
+    case (.none, .none):
+      equals = true
+    default:
+      equals = false
+    }
+    
+    return (lhs.time == AnyTestTime || rhs.time == AnyTestTime || lhs.time == rhs.time) && equals
+  }
+  
+  func eventsEqual<E: Sequence>(_ lhs: [Recorded<Event<E>>], _ rhs: [Recorded<Event<E>>]) -> Bool where E.Iterator.Element: Equatable {
+    guard lhs.count == rhs.count else { return false }
+    for i in lhs.indices {
+      if !self.eventEquals(lhs[i], rhs[i]) {
+        return false
+      }
+    }
+    return true
+  }
+
 }
 
 
@@ -189,5 +215,32 @@ extension RxAssertion {
     self.assert([], file: file, line: line) { expectedEvents, recordedEvents in
       return !recordedEvents.isEmpty
     }
+  }
+}
+
+// MARK: - Sequence equal
+
+extension RxAssertion where O.E: Sequence, O.E.Iterator.Element: Equatable {
+  
+  public func equal(_ expectedEvents: [Recorded<Event<O.E>>], file: StaticString = #file, line: UInt = #line) {
+    self.assert(expectedEvents, file: file, line: line) { expectedEvents, recordedEvents in
+      return self.eventsEqual(expectedEvents, recordedEvents)
+    }
+  }
+  
+  public func equal(_ expectedElements: [O.E], file: StaticString = #file, line: UInt = #line) {
+    let expectedEvents = expectedElements.map { Recorded(time: AnyTestTime, value: Event.next($0)) }
+    self.equal(expectedEvents, file: file, line: line)
+  }
+  
+  public func notEqual(_ expectedEvents: [Recorded<Event<O.E>>], file: StaticString = #file, line: UInt = #line) {
+    self.assert(expectedEvents, file: file, line: line) { expectedEvents, recordedEvents in
+      return !self.eventsEqual(expectedEvents, recordedEvents)
+    }
+  }
+  
+  public func notEqual(_ expectedElements: [O.E], file: StaticString = #file, line: UInt = #line) {
+    let expectedEvents = expectedElements.map { Recorded(time: AnyTestTime, value: Event.next($0)) }
+    self.notEqual(expectedEvents, file: file, line: line)
   }
 }

--- a/Tests/RxExpectTests.swift
+++ b/Tests/RxExpectTests.swift
@@ -21,12 +21,35 @@
 // SOFTWARE.
 
 import XCTest
+import RxSwift
+import RxTest
 @testable import RxExpect
 
 class RxExpectTests: XCTestCase {
 
   func testSuccess() {
     XCTAssertTrue(true)
+  }
+  
+  func testAssertArrayEquals() {
+    RxExpect("it should be able to compare arrays that are the result of observables") { test in
+      let value = PublishSubject<[Int]>()
+      
+      test.input(value, [ next(25, []), next(50, [0])])
+      test.assert(value).equal([[], [0]])
+    }
+  }
+  
+  func testArrayNotEquals() {
+    RxExpect("it should be able to compare to see if the resulting array from an observable is not equal to a provided value") { test in
+      let value = PublishSubject<[Int]>()
+      
+      test.input(value, [ next(25, []), next(50, [0])])
+      
+      // Note: [] doesn't work; the compiler cannot infer element type without context and therefore doesn't know if it complies with Equatable
+      let result: [Int] = []
+      test.assert(value).notEqual([result])
+    }
   }
 
 }


### PR DESCRIPTION
`Sequence`s (arrays etc) don't conform to the `Equatable` protocol and
therefore couldn't be used in an assert call. For example take a
ViewModel that produces lists of objects to hook up to a TableView. The
only option was to check .is(Not)Empty and not assert the contents of
the sequences to make sure the ViewModel behaves correctly.

This feature add support for `Sequence`s to contain elements that are `Equatable`. The code is almost similar to the existing code but because of different generic constraint I didn't see a way to reuse/generify more. Improvements/comments on this are welcome.

Also a limitation exists on comparing the result to an empty array; Swift doesn't know the type of the elements of the array so the code doesn't compile. You need to explicitly specify type of the elements of the empty array; see test-case.