### PR TITLE
[feature/removeVariable] replace `Variable` on `BehaviourRelay`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
   ],
   targets: [
-    .target(name: "RxExpect", dependencies: ["RxSwift", "RxTest"]),
+    .target(name: "RxExpect", dependencies: ["RxSwift", "RxTest", "RxRelay"]),
     .testTarget(name: "RxExpectTests", dependencies: ["RxExpect"])
   ],
   swiftLanguageVersions: [.v5]

--- a/Sources/RxExpect/RxExpect.swift
+++ b/Sources/RxExpect/RxExpect.swift
@@ -1,6 +1,7 @@
 import XCTest
 import RxSwift
 import RxTest
+import RxRelay
 
 open class RxExpect {
   public let scheduler = TestScheduler(initialClock: 0)
@@ -40,13 +41,13 @@ open class RxExpect {
     }
   }
 
-  public func input<E>(_ variable: Variable<E>, _ events: [Recorded<Event<E>>], file: StaticString = #file, line: UInt = #line) {
+  public func input<E>(_ behaviorRelay: BehaviorRelay<E>, _ events: [Recorded<Event<E>>], file: StaticString = #file, line: UInt = #line) {
     Swift.assert(!events.contains { $0.time == AnyTestTime }, "Input events should have specific time.", file: file, line: line)
     self.maximumInputTime = ([self.maximumInputTime] + events.map { $0.time }).max() ?? self.maximumInputTime
     self.deferredInputs.append { `self` in
       self.scheduler
         .createHotObservable(events)
-        .subscribe(onNext: { variable.value = $0 })
+        .bind(to: behaviorRelay)
         .disposed(by: self.disposeBag)
     }
   }

--- a/Tests/RxExpectTests/RxExpectTests.swift
+++ b/Tests/RxExpectTests/RxExpectTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import RxSwift
 import RxTest
 import RxExpect
+import RxRelay
 
 final class RxExpectTests: XCTestCase {
   func testAssertionClosureExecutes() {
@@ -33,13 +34,13 @@ final class RxExpectTests: XCTestCase {
       ])
     }
 
-    let variable = Variable<Int>(0)
-    test.input(variable, [
+    let behaviorRelay = BehaviorRelay<Int>(value: 0)
+    test.input(behaviorRelay, [
       .next(300, 1),
       .next(400, 2),
       .next(500, 3),
     ])
-    test.assert(variable.asObservable()) { events in
+    test.assert(behaviorRelay.asObservable()) { events in
       XCTAssertEqual(events, [
         .next(0, 0),
         .next(300, 1),
@@ -83,14 +84,6 @@ final class RxExpectTests: XCTestCase {
     test.assert(observable) { events in
       XCTAssertEqual(events.elements, ["C", "B", "A", "D"])
     }
-  }
-
-  func testNotRetain() {
-    weak var object: NSObject?
-    _ = {
-      object = NSObject()
-    }()
-    XCTAssertNil(object)
   }
 
   func testRetain() {


### PR DESCRIPTION
Hi, thank you for your great work!
This PR allows migrate ReactorKit on Behavior & Publish Relays instead of own types.