### PR TITLE
Let's RxSwift 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
-osx_image: xcode10.2
-language: objective-c
+osx_image: xcode12.2
+language: swift
 sudo: required
 env:
   global:
     - PROJECT="RxExpect.xcodeproj"
     - SCHEME="RxExpect-Package"
-    - IOS_SDK="iphonesimulator12.2"
-    - MACOS_SDK="macosx10.14"
-    - TVOS_SDK="appletvsimulator12.2"
+    - IOS_SDK="iphonesimulator14.2"
+    - MACOS_SDK="macosx11.0"
+    - TVOS_SDK="appletvsimulator14.2"
   matrix:
-    - SDK="$IOS_SDK"      DESTINATION="platform=iOS Simulator,name=iPhone 8,OS=12.2"
+    - SDK="$IOS_SDK"      DESTINATION="platform=iOS Simulator,name=iPhone 12,OS=14.2"
     - SDK="$MACOS_SDK"    DESTINATION="arch=x86_64"
-    - SDK="$TVOS_SDK"     DESTINATION="OS=12.2,name=Apple TV 4K"
+    - SDK="$TVOS_SDK"     DESTINATION="OS=14.2,name=Apple TV 4K"
 
 install:
   - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "b3e888b4972d9bc76495dd74d30a8c7fad4b9395",
-          "version": "5.0.1"
+          "revision": "c8742ed97fc2f0c015a5ea5eddefb064cd7532d2",
+          "version": "6.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .library(name: "RxExpect", targets: ["RxExpect"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
   ],
   targets: [
     .target(name: "RxExpect", dependencies: ["RxSwift", "RxTest"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "RxExpect",
   platforms: [
-    .iOS(.v8), .macOS(.v10_10), .tvOS(.v9)
+    .iOS(.v9), .macOS(.v10_10), .tvOS(.v9)
   ],
   products: [
     .library(name: "RxExpect", targets: ["RxExpect"]),

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
   ],
   targets: [
-    .target(name: "RxExpect", dependencies: ["RxSwift", "RxTest"]),
+    .target(name: "RxExpect", dependencies: ["RxRelay", "RxSwift", "RxTest"]),
     .testTarget(name: "RxExpectTests", dependencies: ["RxExpect"])
   ],
   swiftLanguageVersions: [.v5]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RxExpect
 ========
 
-![Swift](https://img.shields.io/badge/Swift-5.0-orange.svg)
+![Swift](https://img.shields.io/badge/Swift-5.1-orange.svg)
 [![CocoaPods](http://img.shields.io/cocoapods/v/RxExpect.svg)](https://cocoapods.org/pods/RxExpect)
 [![Build Status](https://travis-ci.org/devxoul/RxExpect.svg?branch=master)](https://travis-ci.org/devxoul/RxExpect)
 [![Codecov](https://img.shields.io/codecov/c/github/devxoul/RxExpect.svg)](https://codecov.io/gh/devxoul/RxExpect/)

--- a/RxExpect.podspec
+++ b/RxExpect.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = "9.0"
   
-  s.dependency "RxSwift", "~> 5.0"
-  s.dependency "RxCocoa", "~> 5.0"
-  s.dependency "RxTest", "~> 5.0"
+  s.dependency "RxSwift", "~> 6.0"
+  s.dependency "RxCocoa", "~> 6.0"
+  s.dependency "RxTest", "~> 6.0"
 end

--- a/Sources/RxExpect/RxExpect.swift
+++ b/Sources/RxExpect/RxExpect.swift
@@ -40,17 +40,6 @@ open class RxExpect {
     }
   }
 
-  public func input<E>(_ variable: Variable<E>, _ events: [Recorded<Event<E>>], file: StaticString = #file, line: UInt = #line) {
-    Swift.assert(!events.contains { $0.time == AnyTestTime }, "Input events should have specific time.", file: file, line: line)
-    self.maximumInputTime = ([self.maximumInputTime] + events.map { $0.time }).max() ?? self.maximumInputTime
-    self.deferredInputs.append { `self` in
-      self.scheduler
-        .createHotObservable(events)
-        .subscribe(onNext: { variable.value = $0 })
-        .disposed(by: self.disposeBag)
-    }
-  }
-
   open func assert<O: ObservableConvertibleType>(_ source: O, disposed: TestTime? = nil, closure: @escaping AssertionClosure<O.Element>) {
     let assertion = Assertion(source: source, disposeAt: disposed, closure: closure)
     self.assertions.append(assertion)

--- a/Tests/RxExpectTests/RxExpectTests.swift
+++ b/Tests/RxExpectTests/RxExpectTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import RxRelay
 import RxSwift
 import RxTest
 import RxExpect
@@ -30,6 +31,35 @@ final class RxExpectTests: XCTestCase {
         .next(100, "A"),
         .next(200, "B"),
         .completed(300),
+      ])
+    }
+
+    let publishRelay = PublishRelay<Int>()
+    test.input(publishRelay, [
+      .next(300, 1),
+      .next(400, 2),
+      .next(500, 3),
+    ])
+    test.assert(publishRelay.asObservable()) { events in
+      XCTAssertEqual(events, [
+        .next(300, 1),
+        .next(400, 2),
+        .next(500, 3),
+      ])
+    }
+
+    let behaviorRelay = BehaviorRelay<Int>(value: 0)
+    test.input(behaviorRelay, [
+      .next(300, 1),
+      .next(400, 2),
+      .next(500, 3),
+    ])
+    test.assert(behaviorRelay.asObservable()) { events in
+      XCTAssertEqual(events, [
+        .next(0, 0),
+        .next(300, 1),
+        .next(400, 2),
+        .next(500, 3),
       ])
     }
   }

--- a/Tests/RxExpectTests/RxExpectTests.swift
+++ b/Tests/RxExpectTests/RxExpectTests.swift
@@ -32,21 +32,6 @@ final class RxExpectTests: XCTestCase {
         .completed(300),
       ])
     }
-
-    let variable = Variable<Int>(0)
-    test.input(variable, [
-      .next(300, 1),
-      .next(400, 2),
-      .next(500, 3),
-    ])
-    test.assert(variable.asObservable()) { events in
-      XCTAssertEqual(events, [
-        .next(0, 0),
-        .next(300, 1),
-        .next(400, 2),
-        .next(500, 3),
-      ])
-    }
   }
 
   func testAssertInfiniteObservable() {

--- a/Tests/RxExpectTests/RxExpectTests.swift
+++ b/Tests/RxExpectTests/RxExpectTests.swift
@@ -54,7 +54,7 @@ final class RxExpectTests: XCTestCase {
   func testAssertMergeOnMainScheduler() {
     let test = RxExpect()
     let subjects: [PublishSubject<String>] = [.init(), .init(), .init()]
-    let observable = Observable<String>.merge(subjects).observeOn(MainScheduler.instance)
+    let observable = Observable<String>.merge(subjects).observe(on: MainScheduler.instance)
     test.input(subjects[0], [
       .next(500, "A"),
     ])


### PR DESCRIPTION
- Update RxSwift to [6.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/6.0.0)
- Bump deployment target to iOS 9 because RxSwift supports iOS9 and above only.
- Use Swift 5.1
- Use Xcode 12.2 on Travis